### PR TITLE
[BiYfeOa1] Change content offset

### DIFF
--- a/CHMeetupApp/Sources/ViewControllers/Events/Registration/Preview/RegistrationPreviewViewController.swift
+++ b/CHMeetupApp/Sources/ViewControllers/Events/Registration/Preview/RegistrationPreviewViewController.swift
@@ -167,7 +167,8 @@ extension RegistrationPreviewViewController: KeyboardHandlerDelegate {
 
     switch state {
     case .frameChanged, .opened:
-      let tableViewBottomContentInsets = info.endFrame.height + tableView.defaultBottomInset
+      // 15 is necessary offset due to the feature of the projected cell
+      let tableViewBottomContentInsets = info.endFrame.height + 15 + tableView.defaultBottomInset
       tableView.contentInset.bottom = tableViewBottomContentInsets
       tableView.scrollIndicatorInsets.bottom = info.endFrame.height + bottomButton.frame.height
       buttonInsets = info.endFrame.height


### PR DESCRIPTION
**Тема ревью**
Сдвинуть чуть-чуть контент выше, чтобы полностью было видно `textField`

**Описание ревью**
Сдвинул контент на 15 точек выше, так как это самый оптимальный вариант был, тестировал на симуляторах от IPhone 7 plus до iPhone 5s

**На что обратить внимание и как тестировать**
Запустить приложение, перейти на экран регистрации на эвент и нажать на textField

**Связанные таски**
https://trello.com/c/BiYfeOa1/188-textfield