### PR TITLE
[2z4mtlfy] Added transitions

### DIFF
--- a/CHMeetupApp/Sources/ViewControllers/Events/EventPreview/DisplayModel/EventPreviewDisplayCollection.swift
+++ b/CHMeetupApp/Sources/ViewControllers/Events/EventPreview/DisplayModel/EventPreviewDisplayCollection.swift
@@ -152,4 +152,15 @@ class EventPreviewDisplayCollection: DisplayCollection {
       break
     }
   }
+
+  func didTransition(navigationController: UINavigationController) {
+    if LoginProcessController.isLogin {
+      let viewController = Storyboards.EventPreview.instantiateRegistrationPreviewViewController()
+      delegate?.push(viewController: viewController)
+    } else {
+      let viewController = Storyboards.Profile.instantiateAuthViewController()
+      viewController.targetViewController = Storyboards.EventPreview.instantiateRegistrationPreviewViewController()
+      delegate?.push(viewController: viewController)
+    }
+  }
 }

--- a/CHMeetupApp/Sources/ViewControllers/Events/EventPreview/EventPreviewViewController.swift
+++ b/CHMeetupApp/Sources/ViewControllers/Events/EventPreview/EventPreviewViewController.swift
@@ -60,8 +60,9 @@ class EventPreviewViewController: UIViewController {
   }
 
   func acceptAction() {
-    let viewController = Storyboards.EventPreview.instantiateRegistrationPreviewViewController()
-    navigationController?.pushViewController(viewController, animated: true)
+    if let navigationController = navigationController {
+      displayCollection.didTransition(navigationController: navigationController)
+    }
   }
 }
 

--- a/CHMeetupApp/Sources/ViewControllers/Profile/Auth/AuthViewController.swift
+++ b/CHMeetupApp/Sources/ViewControllers/Profile/Auth/AuthViewController.swift
@@ -28,11 +28,18 @@ class AuthViewController: UIViewController, ProfileHierarhyViewControllerType {
     }
   }
 
+  var targetViewController: UIViewController?
+
   override func viewDidLoad() {
     super.viewDidLoad()
     title = "Auth".localized
     // FIXME: delete it when implement twitter auth
     authButtons[2].isHidden = true
+  }
+
+  override func viewDidAppear(_ animated: Bool) {
+    super.viewDidAppear(animated)
+    profileNavigationController?.updateRootViewController()
   }
 
   @IBAction func loginAction(_ sender: UIButton) {
@@ -49,7 +56,14 @@ class AuthViewController: UIViewController, ProfileHierarhyViewControllerType {
         return
       }
       LoginProcessController.setCurrentUser(user)
-      self?.profileNavigationController?.updateRootViewController()
+
+      if let target = self?.targetViewController, let navigationController = self?.navigationController {
+        navigationController.viewControllers.insert(target, at: navigationController.viewControllers.count-1)
+        navigationController.popViewController(animated: true)
+      } else {
+        self?.profileNavigationController?.updateRootViewController()
+      }
+
     }
   }
 }

--- a/CHMeetupApp/Sources/ViewControllers/Profile/NavigationController/ProfileNavigationViewController.swift
+++ b/CHMeetupApp/Sources/ViewControllers/Profile/NavigationController/ProfileNavigationViewController.swift
@@ -23,9 +23,13 @@ class ProfileNavigationViewController: NavigationViewController, ProfileNavigati
 
   func updateRootViewController() {
     if LoginProcessController.isLogin {
-      viewControllers = [ViewControllersFactory.profileViewController]
+      if !viewControllers.contains(where: {$0 is ProfileViewController}) {
+        viewControllers = [ViewControllersFactory.profileViewController]
+      }
     } else {
-      viewControllers = [ViewControllersFactory.authViewController]
+      if !viewControllers.contains(where: {$0 is AuthViewController}) {
+        viewControllers = [ViewControllersFactory.authViewController]
+      }
     }
   }
 


### PR DESCRIPTION
**Тема ревью**
Создать роутер для RegistrationPreviewViewController

**Описание ревью**
Если пользователь не авторизован, то перед регистрацией на евент происходит переход на авторизацию, после которой возвращаемся к регистрации на евент.
PS: работает, но вот решение мне не нравится (замарок с ProfileNavigationControllerType)
PS2: при тестировании обнаружил, что если туда сюда login logout, то выскакивает ошибка: **Error with login has occured**. Нужно отдельный таск на это.

**На что обратить внимание и как тестировать**
Разлогиниться, в эвенте нажать "Я пойду", должен открыться экран авторизации, после успешной авторизации, переход на экран регистрации.

**Связанные таски**
https://trello.com/c/2z4mtlfy