### PR TITLE
[6Jc709jc] Added ImportEventStatusEntity and PlainObject

### DIFF
--- a/CHMeetupApp.xcodeproj/project.pbxproj
+++ b/CHMeetupApp.xcodeproj/project.pbxproj
@@ -100,6 +100,8 @@
 		4D9F0D701E79CD2E006443ED /* ActionTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D9F0D6E1E79CD2E006443ED /* ActionTableViewCell.swift */; };
 		4D9F0D711E79CD2E006443ED /* ActionTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4D9F0D6F1E79CD2E006443ED /* ActionTableViewCell.xib */; };
 		4DA530251E5FCDB900CD74EB /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 4DA530241E5FCDB900CD74EB /* Main.storyboard */; };
+		4DD1D6A91EB1385300F7A9DB /* ImportEventStatusEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DD1D6A81EB1385300F7A9DB /* ImportEventStatusEntity.swift */; };
+		4DD1D6AC1EB138F500F7A9DB /* ImportEventStatusPlainObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DD1D6AB1EB138F500F7A9DB /* ImportEventStatusPlainObject.swift */; };
 		784EFF931E637EA500F2E31A /* RealmController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 784EFF921E637EA500F2E31A /* RealmController.swift */; };
 		784EFF951E637EAE00F2E31A /* RealmSwift.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8A6268281E60742B00D51BEB /* RealmSwift.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		7D1CB6D01EA27ADC003136FA /* UIView+Shake.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D1CB6CF1EA27ADC003136FA /* UIView+Shake.swift */; };
@@ -348,6 +350,8 @@
 		4D9F0D6E1E79CD2E006443ED /* ActionTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ActionTableViewCell.swift; path = ActionCell/ActionTableViewCell.swift; sourceTree = "<group>"; };
 		4D9F0D6F1E79CD2E006443ED /* ActionTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; name = ActionTableViewCell.xib; path = ActionCell/ActionTableViewCell.xib; sourceTree = "<group>"; };
 		4DA530241E5FCDB900CD74EB /* Main.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Main.storyboard; sourceTree = "<group>"; };
+		4DD1D6A81EB1385300F7A9DB /* ImportEventStatusEntity.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImportEventStatusEntity.swift; sourceTree = "<group>"; };
+		4DD1D6AB1EB138F500F7A9DB /* ImportEventStatusPlainObject.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ImportEventStatusPlainObject.swift; path = ImportEventStatus/ImportEventStatusPlainObject.swift; sourceTree = "<group>"; };
 		784EFF921E637EA500F2E31A /* RealmController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RealmController.swift; sourceTree = "<group>"; };
 		7D1CB6CF1EA27ADC003136FA /* UIView+Shake.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIView+Shake.swift"; sourceTree = "<group>"; };
 		7D1CB6D11EA2B8E9003136FA /* UITableView+ShakeSection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UITableView+ShakeSection.swift"; sourceTree = "<group>"; };
@@ -688,6 +692,7 @@
 				9FAFF80C1E6ADB8200B687CB /* PlaceEntity.swift */,
 				9FF708DA1E6ADC9900BBA992 /* SocialEntity.swift */,
 				9FD42F6A1E95385000EA6EE7 /* StringContainerEntity.swift */,
+				4DD1D6A81EB1385300F7A9DB /* ImportEventStatusEntity.swift */,
 			);
 			path = Entities;
 			sourceTree = "<group>";
@@ -951,6 +956,7 @@
 			isa = PBXGroup;
 			children = (
 				22323F4C1E70C18700522E5C /* PlainObjectType.swift */,
+				4DD1D6AA1EB138AC00F7A9DB /* ImportStatus */,
 				7D1E275D1E958C2D0005B861 /* Request */,
 				9FD594911E87188600BAD1B5 /* SpeechContent */,
 				9FD5948E1E87182800BAD1B5 /* Speech */,
@@ -1284,6 +1290,14 @@
 				4D9F0D6F1E79CD2E006443ED /* ActionTableViewCell.xib */,
 			);
 			name = ActionCell;
+			sourceTree = "<group>";
+		};
+		4DD1D6AA1EB138AC00F7A9DB /* ImportStatus */ = {
+			isa = PBXGroup;
+			children = (
+				4DD1D6AB1EB138F500F7A9DB /* ImportEventStatusPlainObject.swift */,
+			);
+			name = ImportStatus;
 			sourceTree = "<group>";
 		};
 		7D1CB6D31EA2D208003136FA /* Creators */ = {
@@ -2187,6 +2201,7 @@
 				9F30FFCD1E71E77700EF85F5 /* UITableView+Registration.swift in Sources */,
 				9F487A821E7417F50016CE0B /* LightButton.swift in Sources */,
 				9F487A7A1E740DC00016CE0B /* EventPreviewTableViewCell.swift in Sources */,
+				4DD1D6A91EB1385300F7A9DB /* ImportEventStatusEntity.swift in Sources */,
 				221CC3FC1E7B24A1004F0695 /* EventRegFormFieldPlainObject.swift in Sources */,
 				221A8B891E685EBF004E320D /* String+Localized.swift in Sources */,
 				7DE942111E869A6F00E7E9E6 /* FBResource.swift in Sources */,
@@ -2219,6 +2234,7 @@
 				328467551E7FF18400028431 /* TimePlaceTableViewCell.swift in Sources */,
 				C30485B31E740FDE0052D632 /* UIView+Anchor.swift in Sources */,
 				F73C4AAB1EA11CA000E7943C /* GroupImageLoader.swift in Sources */,
+				4DD1D6AC1EB138F500F7A9DB /* ImportEventStatusPlainObject.swift in Sources */,
 				4D0E6B561E86E11100C44DC0 /* ActionCellConfigurationController.swift in Sources */,
 				A168379A1E7E979800A12B3B /* OptionTableViewCell.swift in Sources */,
 				22323F121E70C0D500522E5C /* DateComponents+Init.swift in Sources */,

--- a/CHMeetupApp/Sources/Common/Helpers/TranslationEventPlainObject.swift
+++ b/CHMeetupApp/Sources/Common/Helpers/TranslationEventPlainObject.swift
@@ -34,9 +34,15 @@ struct EventPlainObjectTranslation: PlainObjectTranslation {
     place.city = plainObject.place.cityName
     event.place = place
 
+    let isAdded = ImportEventStatusEntity()
+    isAdded.toCalendar = plainObject.isAdded.toCalendar
+    isAdded.toReminder = plainObject.isAdded.toReminder
+    event.isAdded = isAdded
+
     realmWrite {
       mainRealm.add(event, update: true)
       mainRealm.add(place, update: true)
+      mainRealm.add(isAdded, update: false)
     }
   }
 }

--- a/CHMeetupApp/Sources/Model/Entities/EventEntity.swift
+++ b/CHMeetupApp/Sources/Model/Entities/EventEntity.swift
@@ -21,6 +21,7 @@ class EventEntity: Object {
   dynamic var photoURL: String = ""
 
   dynamic var place: PlaceEntity?
+  dynamic var isAdded: ImportEventStatusEntity?
   dynamic var isRegistrationOpen: Bool = false
 
   let speeches = List<SpeechEntity>()

--- a/CHMeetupApp/Sources/Model/Entities/ImportEventStatusEntity.swift
+++ b/CHMeetupApp/Sources/Model/Entities/ImportEventStatusEntity.swift
@@ -1,0 +1,15 @@
+//
+//  ImportEventStatusEntity.swift
+//  CHMeetupApp
+//
+//  Created by Егор Петров on 26/04/2017.
+//  Copyright © 2017 CocoaHeads Community. All rights reserved.
+//
+
+import Foundation
+import RealmSwift
+
+class ImportEventStatusEntity: Object {
+  dynamic var toCalendar = false
+  dynamic var toReminder = false
+}

--- a/CHMeetupApp/Sources/Model/Helpers/RealmController.swift
+++ b/CHMeetupApp/Sources/Model/Helpers/RealmController.swift
@@ -15,7 +15,7 @@ class RealmController {
 
   func setup() {
     Realm.Configuration.defaultConfiguration =
-      Realm.Configuration(schemaVersion: 13, migrationBlock: nil)
+      Realm.Configuration(schemaVersion: 14, migrationBlock: nil)
 
     do {
       mainRealm = try Realm()

--- a/CHMeetupApp/Sources/Model/PlainObjects/Event/EventPlainObject+Requests.swift
+++ b/CHMeetupApp/Sources/Model/PlainObjects/Event/EventPlainObject+Requests.swift
@@ -50,6 +50,10 @@ extension EventPlainObject: PlainObjectType {
     self.startDate = Date(timeIntervalSince1970: startDate)
     self.endDate = Date(timeIntervalSince1970: endDate)
 
+    // FIXME: Delete when add request from server
+    let isAdded = ImportEventStatusPlainObject(toCalendar: false, toReminder: false)
+    self.isAdded = isAdded
+    
     var photos: [URL] = []
     speakersJson.forEach { photoUrl in
       guard let url = URL(string: photoUrl) else { return }

--- a/CHMeetupApp/Sources/Model/PlainObjects/Event/EventPlainObject.swift
+++ b/CHMeetupApp/Sources/Model/PlainObjects/Event/EventPlainObject.swift
@@ -14,6 +14,7 @@ struct EventPlainObject {
   let description: String
   let photoUrl: String
   let place: PlacePlainObject
+  let isAdded: ImportEventStatusPlainObject
   let isRegistrationOpen: Bool
   let startDate: Date
   let endDate: Date

--- a/CHMeetupApp/Sources/Model/PlainObjects/ImportEventStatus/ImportEventStatusPlainObject.swift
+++ b/CHMeetupApp/Sources/Model/PlainObjects/ImportEventStatus/ImportEventStatusPlainObject.swift
@@ -1,0 +1,14 @@
+//
+//  ImportEventStatusPlainObject.swift
+//  CHMeetupApp
+//
+//  Created by Егор Петров on 26/04/2017.
+//  Copyright © 2017 CocoaHeads Community. All rights reserved.
+//
+
+import Foundation
+
+struct ImportEventStatusPlainObject {
+  let toCalendar: Bool
+  let toReminder: Bool
+}


### PR DESCRIPTION
**Тема ревью**
Добавить ImportEventStatusEntity и PlainObject для того чтобы отслеживать добавил пользователь событие в напоминания и календарь или нет

**Описание ревью**
Добавил ImportEventStatusEntity и PlainObject, а также их обработку в EventEntity и EventPlainObject

**На что обратить внимание и как тестировать**
Проверить код

**Связанные таски**
https://trello.com/c/6Jc709jc/277-importeventstatusentity