### PR TITLE
[OG2yVvPh] Fixed textfield bug

### DIFF
--- a/CHMeetupApp/Sources/ViewControllers/Profile/GiveSpeech/TextFieldPlateTableViewCell.xib
+++ b/CHMeetupApp/Sources/ViewControllers/Profile/GiveSpeech/TextFieldPlateTableViewCell.xib
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11762" systemVersion="16D32" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="12121" systemVersion="16F73" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12089"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -23,7 +23,7 @@
                         <rect key="frame" x="24" y="24" width="272" height="44.5"/>
                         <nil key="textColor"/>
                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                        <textInputTraits key="textInputTraits"/>
+                        <textInputTraits key="textInputTraits" autocorrectionType="no"/>
                         <connections>
                             <action selector="textFieldTextChanged:" destination="KGk-i7-Jjw" eventType="editingChanged" id="3md-c5-v8A"/>
                         </connections>


### PR DESCRIPTION
**Тема ревью**
Пофиксисть баг TextField

**Описание ревью**
При смене фокуса наблюдался подскок. Это было связано с включенной коррекцией ввода, как только я ее отключил, все стало норм.

**На что обратить внимание и как тестировать**
Проверте пожалуйста, на экранах Стать спикером и в особенности на экране регистрации (на который я не смог попасть, не подгрузился)

**Связанные таски**
https://trello.com/c/OG2yVvPh/268-скачет-поле-название-на-странице-стать-спикером
https://trello.com/c/w01MedTp/208-проверить-textfield-в-форме-регистрации-при-смещении-фокуса-на-поле-происходит-подскок