### PR TITLE
[F7DX0gLs] Added russian value

### DIFF
--- a/CHMeetupApp/Sources/Common/Helpers/AttributedStringHelper/AttributedSentenceHelper.swift
+++ b/CHMeetupApp/Sources/Common/Helpers/AttributedStringHelper/AttributedSentenceHelper.swift
@@ -14,7 +14,10 @@ class AttributedSentenceHelper {
     case at
 
     var localizedValue: String {
-      return self.rawValue.localized
+      switch self {
+      case .at:
+        return "в".localized
+      }
     }
 
     func concatString(firstPartString: String?, secondPartString: String?)


### PR DESCRIPTION
**Тема ревью**
Баг локализации на экране профиля

**Описание ревью**
Исправил значение с "at" на "в"

**На что обратить внимание и как тестировать**
Зайти в профиль

**Связанные таски**
https://trello.com/c/F7DX0gLs/342-на-экране-профиля-осталось-position-at-company-на-английском