### PR TITLE
[n42xW8HS] Fixed event actions bug

### DIFF
--- a/CHMeetupApp/Sources/ViewControllers/Events/EventPreview/DisplayModel/EventPreviewDisplayCollection.swift
+++ b/CHMeetupApp/Sources/ViewControllers/Events/EventPreview/DisplayModel/EventPreviewDisplayCollection.swift
@@ -143,7 +143,10 @@ class EventPreviewDisplayCollection: DisplayCollection {
     case .speaches:
       return speeches.count
     case .additionalCells:
-      return event != nil ? actionPlainObjects.count : 0
+      if let event = event, event.isUpcomingEvent {
+        return actionPlainObjects.count
+      }
+      return 0
     }
   }
 


### PR DESCRIPTION
**Тема ревью**
В прошедших событиях доступно добавление в календарь и в напоминания

**Описание ревью**
Не хватало проверки на isUpcomingEvent

**На что обратить внимание и как тестировать**
Зайти на предстоящия мероприятия и на прошедшие, кнопки лобавления в календарь и напоминания должны быть доступны только для предстоящих событий.

**Связанные таски**
https://trello.com/c/n42xW8HS/360-в-прошедших-событиях-доступно-добавление-в-календарь-и-напоминания