### PR TITLE
[5nGoZdKo] Fix bug with user state

### DIFF
--- a/CHMeetupApp/Sources/ViewControllers/Feed/Main/MainViewController.swift
+++ b/CHMeetupApp/Sources/ViewControllers/Feed/Main/MainViewController.swift
@@ -10,7 +10,6 @@ import UIKit
 
 class MainViewController: UIViewController, DisplayCollectionWithTableViewDelegate {
 
-  var currentUserId: Int? = -1
   private var userActiveState: Bool = false
 
   @IBOutlet var tableView: UITableView! {
@@ -29,7 +28,7 @@ class MainViewController: UIViewController, DisplayCollectionWithTableViewDelega
     displayCollection.delegate = self
     tableView.registerNibs(from: displayCollection)
     setCurrentState()
-
+    fetchEvents()
     title = "CocoaHeads Russia".localized
     // Do any additional setup after loading the view.
   }
@@ -38,18 +37,10 @@ class MainViewController: UIViewController, DisplayCollectionWithTableViewDelega
     super.viewWillAppear(animated)
     self.tableView.reloadData()
 
-    if currentUserId != UserPreferencesEntity.value.currentUser?.remoteId {
-      fetchEvents()
-      currentUserId = UserPreferencesEntity.value.currentUser?.remoteId
-    }
-
     if LoginProcessController.isLogin != userActiveState {
       fetchEvents()
+      setCurrentState()
     }
-  }
-
-  override func viewDidDisappear(_ animated: Bool) {
-    setCurrentState()
   }
 
   override func customTabBarItemContentView() -> CustomTabBarItemView {


### PR DESCRIPTION
**Тема ревью**
Проверка состояния заявки после авторизации

**Описание ревью**
Теперь статус заявки на мероприятие на главном экране после авторизации показывает верное состояние

**На что обратить внимание и как тестировать**
Войти в приложение, разлогиниться, снова залогиниться и перейти на main экран. Статус заявки не должен быть "loading"

**Связанные таски**
https://trello.com/c/5nGoZdKo/361-чекать-состояние-заявки-после-авторизации