### PR TITLE
Bugfix/Support iPhone X

### DIFF
--- a/CHMeetupApp/Resources/Storyboards/Main.storyboard
+++ b/CHMeetupApp/Resources/Storyboards/Main.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12121" systemVersion="16G29" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="ifu-eV-gt1">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13196" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="ifu-eV-gt1">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12089"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13173"/>
         <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="Constraints with non-1.0 multipliers" minToolsVersion="5.1"/>
@@ -95,7 +95,7 @@
                     <tabBar key="tabBar" contentMode="scaleToFill" id="ZHN-fJ-flQ" customClass="AZTabBar" customModule="CHMeetupApp" customModuleProvider="target">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="49"/>
                         <autoresizingMask key="autoresizingMask"/>
-                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     </tabBar>
                     <connections>
                         <segue destination="OrX-Cc-xgJ" kind="relationship" relationship="viewControllers" id="ogv-G9-Tza"/>
@@ -114,7 +114,7 @@
                     <tabBarItem key="tabBarItem" systemItem="more" id="EYz-le-H70" customClass="AZTabBarItem" customModule="CHMeetupApp" customModuleProvider="target"/>
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="N3A-KA-XJg">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                        <rect key="frame" x="0.0" y="20" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
@@ -133,7 +133,7 @@
                     <tabBarItem key="tabBarItem" systemItem="featured" id="nq2-nd-hlH" customClass="AZTabBarItem" customModule="CHMeetupApp" customModuleProvider="target"/>
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="QMh-77-fMm">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                        <rect key="frame" x="0.0" y="20" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
@@ -151,7 +151,7 @@
                 <navigationController id="b0P-Mq-rOD" customClass="ProfileNavigationViewController" customModule="CHMeetupApp" customModuleProvider="target" sceneMemberID="viewController">
                     <tabBarItem key="tabBarItem" systemItem="history" id="pqo-Bx-yIv" customClass="AZTabBarItem" customModule="CHMeetupApp" customModuleProvider="target"/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="2v7-Da-U4X">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                        <rect key="frame" x="0.0" y="20" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                 </navigationController>
@@ -172,19 +172,19 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Спасибо. Операция успешно выполнена." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jX1-ki-AHJ">
-                                <rect key="frame" x="16" y="313" width="343" height="18"/>
+                                <rect key="frame" x="16" y="312" width="343" height="18"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                 <nil key="textColor"/>
                                 <color key="highlightedColor" cocoaTouchSystemColor="lightTextColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Красавчик!" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5IW-cH-Clj">
-                                <rect key="frame" x="16" y="278.5" width="343" height="26.5"/>
+                                <rect key="frame" x="16" y="280" width="343" height="24"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="UPC-P9-wtf" customClass="LightButton" customModule="CHMeetupApp" customModuleProvider="target">
-                                <rect key="frame" x="44" y="347" width="287" height="58"/>
+                                <rect key="frame" x="44" y="346" width="287" height="58"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="58" id="Y6y-Qo-NPl"/>
                                 </constraints>
@@ -194,7 +194,7 @@
                                 </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8S2-Op-FCm">
-                                <rect key="frame" x="147.5" y="190.5" width="80" height="80"/>
+                                <rect key="frame" x="147.5" y="192" width="80" height="80"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="80" id="8AA-Oi-J5e"/>
                                     <constraint firstAttribute="width" secondItem="8S2-Op-FCm" secondAttribute="height" multiplier="1:1" id="K4J-Qs-CBn"/>

--- a/CHMeetupApp/Sources/Common/Views/BottomButton.swift
+++ b/CHMeetupApp/Sources/Common/Views/BottomButton.swift
@@ -43,6 +43,9 @@ class BottomButton: ActionButton {
   private struct Constants {
     static var height: CGFloat = 50
     static var titleFont: UIFont = UIFont.appFont(.avenirNextDemiBold(size: 16))
+    static var cornerRadius = Constants.height / 2.0
+    static var leadingConstant: CGFloat = 8.0
+    static var trailingConstant: CGFloat = -8.0
   }
 
   static var constantHeight: CGFloat {
@@ -64,9 +67,17 @@ class BottomButton: ActionButton {
     view.addSubview(self)
     anchor(leading: view.leadingAnchor,
            trailing: view.trailingAnchor,
+           leadingConstant: Constants.leadingConstant,
+           trailingConstant: Constants.trailingConstant,
            heightConstant: Constants.height)
+    
+    self.layer.cornerRadius = Constants.cornerRadius
 
-    bottomConstraint = bottomAnchor.constraint(equalTo: view.bottomAnchor)
+    if #available(iOS 11.0, *) {
+      bottomConstraint = bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
+    } else {
+      bottomConstraint = bottomAnchor.constraint(equalTo: view.bottomAnchor)
+    }
     bottomConstraint.isActive = true
 
     setTitle(title, for: .normal)

--- a/CHMeetupApp/Sources/ViewControllers/Base/AZTabBarController.swift
+++ b/CHMeetupApp/Sources/ViewControllers/Base/AZTabBarController.swift
@@ -120,18 +120,19 @@ public class AZTabBar: UITabBar {
 
   override public func sizeThatFits(_ size: CGSize) -> CGSize {
     var size = super.sizeThatFits(size)
-    size.height = preferedHeight
+    
+    if #available(iOS 11.0, *), let bottomInset = superview?.safeAreaInsets.bottom {
+      size.height = bottomInset + preferedHeight
+    } else {
+      size.height = preferedHeight
+    }
     return size
   }
 
   override public var alpha: CGFloat {
     didSet {
-      for view in subviews {
-        if view is AZTabBarItemView {
-          view.alpha = alpha
-        } else {
-          view.alpha = 0.0
-        }
+      subviews.forEach {
+        $0.alpha = $0 is AZTabBarItemView ? alpha : 0.0
       }
     }
   }
@@ -215,8 +216,12 @@ public class AZTabBarController: UITabBarController {
       }
 
       tabBar.addSubview(viewContainer)
-      az_itemViewConstraints.append(tabBar.bottomAnchor.constraint(equalTo: viewContainer.bottomAnchor))
-
+      if #available(iOS 11.0, *) {
+        az_itemViewConstraints.append(view.safeAreaLayoutGuide.bottomAnchor.constraint(equalTo: viewContainer.bottomAnchor))
+      } else {
+        az_itemViewConstraints.append(tabBar.bottomAnchor.constraint(equalTo: viewContainer.bottomAnchor))
+      }
+      
       if index > 0 {
         az_itemViewConstraints.append(az_items[index - 1].containerView.rightAnchor.constraint(equalTo: viewContainer.leftAnchor))
         az_itemViewConstraints.append(az_items[index - 1].containerView.widthAnchor.constraint(equalTo: viewContainer.widthAnchor))

--- a/CHMeetupApp/Sources/ViewControllers/Base/AZTabBarController.swift
+++ b/CHMeetupApp/Sources/ViewControllers/Base/AZTabBarController.swift
@@ -156,7 +156,7 @@ extension UIViewController {
   }
 }
 
-public class AZTabBarItemView: UITabBarController {
+public class AZTabBarController: UITabBarController {
 
   @IBInspectable public var preferedHeight: CGFloat = defaultHeight {
     didSet {

--- a/CHMeetupApp/Sources/ViewControllers/Base/AZTabBarController.swift
+++ b/CHMeetupApp/Sources/ViewControllers/Base/AZTabBarController.swift
@@ -156,7 +156,7 @@ extension UIViewController {
   }
 }
 
-public class AZTabBarController: UITabBarController {
+public class AZTabBarItemView: UITabBarController {
 
   @IBInspectable public var preferedHeight: CGFloat = defaultHeight {
     didSet {

--- a/CHMeetupApp/Sources/ViewControllers/Base/AZTabBarController.swift
+++ b/CHMeetupApp/Sources/ViewControllers/Base/AZTabBarController.swift
@@ -106,7 +106,21 @@ public class AZTabBarItem: UITabBarItem {
 public class AZTabBar: UITabBar {
   fileprivate var preferedHeight: CGFloat = defaultHeight
   fileprivate weak var az_tabBarController: AZTabBarController?
-
+ 
+  //UITabBar bug fix:
+  //https://stackoverflow.com/questions/46232929/why-page-push-animation-tabbar-moving-up-in-the-iphone-x.
+  override public var frame: CGRect {
+    get {
+      return super.frame
+    }
+    set {
+      var newFrame = newValue
+      if let superview = self.superview, newFrame.maxY != superview.frame.height {
+        newFrame.origin.y = superview.frame.height - newFrame.height
+      }
+      super.frame = newFrame
+    }
+  }
   // MARK: - Override default methods
 
   override public func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
@@ -131,8 +145,8 @@ public class AZTabBar: UITabBar {
 
   override public var alpha: CGFloat {
     didSet {
-      subviews.forEach {
-        $0.alpha = $0 is AZTabBarItemView ? alpha : 0.0
+      subviews.forEach { view in
+        view.alpha = view is AZTabBarItemView ? alpha : 0.0
       }
     }
   }
@@ -218,6 +232,8 @@ public class AZTabBarController: UITabBarController {
       tabBar.addSubview(viewContainer)
       if #available(iOS 11.0, *) {
         az_itemViewConstraints.append(view.safeAreaLayoutGuide.bottomAnchor.constraint(equalTo: viewContainer.bottomAnchor))
+        az_itemViewConstraints.append(tabBar.topAnchor.constraint(equalTo: viewContainer.topAnchor))
+
       } else {
         az_itemViewConstraints.append(tabBar.bottomAnchor.constraint(equalTo: viewContainer.bottomAnchor))
       }

--- a/CHMeetupApp/Sources/ViewControllers/Events/EventPreview/EventPreviewViewController.swift
+++ b/CHMeetupApp/Sources/ViewControllers/Events/EventPreview/EventPreviewViewController.swift
@@ -37,17 +37,19 @@ class EventPreviewViewController: UIViewController {
     bottomButton?.removeFromSuperview()
 
     var configuration = TableViewConfiguration.default
-    configuration.bottomInset = 8 + (state != .unknown ? BottomButton.constantHeight : 0)
-    configuration.bottomIndicatorInset = (state != .unknown ? BottomButton.constantHeight : 0)
+    configuration.bottomInset = 12.0 + (state != .unknown ? BottomButton.constantHeight : 0)
+    configuration.bottomIndicatorInset = 8.0 + (state != .unknown ? BottomButton.constantHeight : 0)
     tableView.configure(with: .custom(configuration))
 
     switch state {
     case .isRegistrationEnabled:
       bottomButton = BottomButton(addingOnView: view, title: "Я пойду".localized)
       bottomButton?.addTarget(self, action: #selector(acceptAction), for: .touchUpInside)
+      bottomButton?.bottomInsetsConstant = 8.0
     case .canCanceling:
       bottomButton = BottomButton(addingOnView: view, title: "Отменить заявку".localized)
       bottomButton?.addTarget(self, action: #selector(cancelAction), for: .touchUpInside)
+      bottomButton?.bottomInsetsConstant = 8.0
       bottomButton?.style = .canceling
     case .unknown:
       break

--- a/CHMeetupApp/Sources/ViewControllers/Events/Registration/Confirm/RegistrationConfirmViewController.swift
+++ b/CHMeetupApp/Sources/ViewControllers/Events/Registration/Confirm/RegistrationConfirmViewController.swift
@@ -14,8 +14,8 @@ class RegistrationConfirmViewController: UIViewController, UIViewControllerWithT
     didSet {
       tableView.allowsMultipleSelection = true
       let configuration = TableViewConfiguration(
-        bottomInset: 8 + BottomButton.constantHeight,
-        bottomIndicatorInset: BottomButton.constantHeight,
+        bottomInset: 12.0 + BottomButton.constantHeight,
+        bottomIndicatorInset: 8.0 + BottomButton.constantHeight,
         estimatedRowHeight: 44
       )
       tableView.configure(with: .custom(configuration))
@@ -38,6 +38,7 @@ class RegistrationConfirmViewController: UIViewController, UIViewControllerWithT
 
     navigationController?.setNavigationBarHidden(true, animated: true)
     bottomButton = BottomButton(addingOnView: view, title: "Закрыть".localized)
+    bottomButton.bottomInsetsConstant = 8.0
     displayCollection = RegistrationConfirmDisplayCollection()
     tableView.registerNibs(from: displayCollection)
 

--- a/CHMeetupApp/Sources/ViewControllers/Events/Registration/Preview/RegistrationPreviewViewController.swift
+++ b/CHMeetupApp/Sources/ViewControllers/Events/Registration/Preview/RegistrationPreviewViewController.swift
@@ -14,8 +14,8 @@ class RegistrationPreviewViewController: UIViewController, DisplayCollectionWith
     didSet {
       tableView.allowsMultipleSelection = true
       let configuration = TableViewConfiguration(
-                                      bottomInset: 8 + BottomButton.constantHeight,
-                                      bottomIndicatorInset: BottomButton.constantHeight,
+                                      bottomInset: 12 + BottomButton.constantHeight,
+                                      bottomIndicatorInset: 8.0 + BottomButton.constantHeight,
                                       estimatedRowHeight: 44)
       tableView.configure(with: .custom(configuration))
       tableView.registerHeaderNib(for: DefaultTableHeaderView.self)
@@ -40,6 +40,7 @@ class RegistrationPreviewViewController: UIViewController, DisplayCollectionWith
     title = "Регистрация".localized
 
     bottomButton = BottomButton(addingOnView: view, title: "Зарегистрироваться".localized)
+    bottomButton.bottomInsetsConstant = 8.0
     bottomButton.isEnabled = false
 
     displayCollection = FormDisplayCollection()

--- a/CHMeetupApp/Sources/ViewControllers/Profile/Edit/ProfileEditViewController.swift
+++ b/CHMeetupApp/Sources/ViewControllers/Profile/Edit/ProfileEditViewController.swift
@@ -12,8 +12,9 @@ class ProfileEditViewController: UIViewController, ProfileHierarhyViewController
 
   @IBOutlet var tableView: UITableView! {
     didSet {
-      let configuration = TableViewConfiguration(bottomInset: 8)
-      tableView.configure(with: .defaultConfiguration)
+      let configuration = TableViewConfiguration(bottomInset: 12 + BottomButton.constantHeight,
+                                                 bottomIndicatorInset: 8.0 + BottomButton.constantHeight)
+      tableView.configure(with: .custom(configuration))
       tableView.registerHeaderNib(for: DefaultTableHeaderView.self)
     }
   }
@@ -35,6 +36,7 @@ class ProfileEditViewController: UIViewController, ProfileHierarhyViewController
     title = "Изменение профиля".localized
 
     bottomButton = BottomButton(addingOnView: view, title: "Сохранить".localized)
+    bottomButton.bottomInsetsConstant = 8.0
     bottomButton.addTarget(self, action: #selector(saveProfile), for: .touchUpInside)
 
   }

--- a/CHMeetupApp/Sources/ViewControllers/Profile/GiveSpeech/GiveSpeechViewController.swift
+++ b/CHMeetupApp/Sources/ViewControllers/Profile/GiveSpeech/GiveSpeechViewController.swift
@@ -12,7 +12,9 @@ class GiveSpeechViewController: UIViewController, UITableViewDataSource, UITable
 
   @IBOutlet var tableView: UITableView! {
     didSet {
-      let configuration = TableViewConfiguration(bottomInset: 8, estimatedRowHeight: 44)
+      let configuration = TableViewConfiguration(bottomInset: 12 + BottomButton.constantHeight,
+                                                 bottomIndicatorInset: 8.0 + BottomButton.constantHeight,
+                                                 estimatedRowHeight: 44)
       tableView.configure(with: .custom(configuration))
       tableView.registerHeaderNib(for: DefaultTableHeaderView.self)
     }
@@ -33,6 +35,7 @@ class GiveSpeechViewController: UIViewController, UITableViewDataSource, UITable
     navigationItem.title = "Стать спикером".localized
 
     bottomButton = BottomButton(addingOnView: view, title: "Подать заявку".localized)
+    bottomButton.bottomInsetsConstant = 8.0
     bottomButton.addTarget(self, action: #selector(sendSpeech), for: .touchUpInside)
   }
 


### PR DESCRIPTION
**Тема ревью**
Добавил поддержку iPhone X для AZTabBarController. 

**Описание ревью**
- Добавлена констрейнта для каждого AZTabBarItem от safeArea для iOS 11.
- К высоте AZTabBar добавляется bottom safeArea inset от superview.
Теперь на iPhone X правильный отступ для каждого AZTabBarItem и корректная высота AZTabBar:
![screen shot 2017-11-04 at 22 54 59](https://user-images.githubusercontent.com/11536127/32409226-d5a4171a-c1b8-11e7-958d-e6b9c66c483b.png)
.
- В Main.storyboard для AZTabBarController поставлен белый фон - был прозрачный.

**На что обратить внимание и как тестировать**
Проверить работу на iPhone X и любом другом, а также удостовериться, что при изменении preferredHeight у AZTabBarController поведение остается правильным. 
