### PR TITLE
Decrease swift compile time

### DIFF
--- a/CHMeetupApp.xcodeproj/project.pbxproj
+++ b/CHMeetupApp.xcodeproj/project.pbxproj
@@ -2648,6 +2648,7 @@
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_WHOLE_MODULE_OPTIMIZATION = YES;
 			};
 			name = Debug;
 		};
@@ -2690,6 +2691,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_WHOLE_MODULE_OPTIMIZATION = "";
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;


### PR DESCRIPTION
**Тема ревью**
Уменьшение времени компиляции swift файлов. 

**Описание ревью**
Можно включить флаг `SWIFT_WHOLE_MODULE_OPTIMIZATION`, не затрагивая оптимизацию `-O`. 

#### До
![2017-11-05 14 28 04](https://user-images.githubusercontent.com/14925971/32414383-570471ce-c236-11e7-8dad-9b9547d7c2db.png)

#### После
![2017-11-05 14 30 18](https://user-images.githubusercontent.com/14925971/32414384-572138f4-c236-11e7-8962-112d76614001.png)


**На что обратить внимание и как тестировать**

Поставить логирования времени компиляции:
```
defaults write com.apple.dt.Xcode ShowBuildOperationDuration -bool YES
```

Сбилдить после удаления папки Build  до и после изменений.

[Источник](https://jobs.zalando.com/tech/blog/improving-swift-compilation-times-from-12-to-2-minutes/?gh_src=4n3gxh1)


**Review**
Decrease swift sources compile time.

**Review description**
Decrease swift compile time by putting user-defined setting to turn on
SWIFT_WHOLE_MODULE_OPTIMIZATION for debug builds. Still avoiding `-O` optimisation.

#### Before changes
![2017-11-05 14 28 04](https://user-images.githubusercontent.com/14925971/32414383-570471ce-c236-11e7-8dad-9b9547d7c2db.png)

#### After
![2017-11-05 14 30 18](https://user-images.githubusercontent.com/14925971/32414384-572138f4-c236-11e7-8962-112d76614001.png)


**How to test? What pay attention to?**

Turn on showing build time in Xcode:
```
defaults write com.apple.dt.Xcode ShowBuildOperationDuration -bool YES
```

Build after full clean the project before and after suggested changes.

[Source](https://jobs.zalando.com/tech/blog/improving-swift-compilation-times-from-12-to-2-minutes/?gh_src=4n3gxh1)

