### PR TITLE
fixed subscript out of bound index in the TemplateModelCollection

### DIFF
--- a/CHMeetupApp/Sources/Model/Helpers/TemplateModelCollection.swift
+++ b/CHMeetupApp/Sources/Model/Helpers/TemplateModelCollection.swift
@@ -96,6 +96,9 @@ struct TemplateModelCollection<T: TemplateEntity> where T: Object {
   // MARK: - Functionality
 
   subscript(index: Int) -> T {
+    if content.count == 0 && values.count == 0 {
+      assertionFailure("Content & values are empty")
+    }
     return content.count == 0 ? values[index] : content[index]
   }
 }

--- a/CHMeetupApp/Sources/Model/Helpers/TemplateModelCollection.swift
+++ b/CHMeetupApp/Sources/Model/Helpers/TemplateModelCollection.swift
@@ -96,10 +96,6 @@ struct TemplateModelCollection<T: TemplateEntity> where T: Object {
   // MARK: - Functionality
 
   subscript(index: Int) -> T {
-    if isLoading && content.count == 0 {
-      return values[index]
-    } else {
-      return content[index]
-    }
+    return content.count == 0 ? values[index] : content[index]
   }
 }


### PR DESCRIPTION
**Тема ревью**
Исправление креша при неполном свайпе назад на экране событий

**Описание ревью**
Изменен subscript структуры TemplateModelCollection.
Исправлено обращение к элементам пустой коллекции.

**На что обратить внимание и как тестировать**
В ишью указан порядок действий для получение крэша, баг плавающий, тяжело поймать.

**Связанные таски**
https://trello.com/c/AQ4YFjnw/396--