### PR TITLE
fixed use egisterForRemoteNotifications() action from main thread only

### DIFF
--- a/CHMeetupApp/Sources/Common/Helpers/PermissionsManager/PermissionsManager.swift
+++ b/CHMeetupApp/Sources/Common/Helpers/PermissionsManager/PermissionsManager.swift
@@ -106,7 +106,9 @@ final class PermissionsManager {
       }
     case .notifications:
       UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .badge, .sound]) { result, _ in
-        UIApplication.shared.registerForRemoteNotifications()
+        DispatchQueue.main.async {
+          UIApplication.shared.registerForRemoteNotifications()
+        }
         completion(result)
       }
     case .photosLibrary:


### PR DESCRIPTION
**Тема ревью**
Использование метода  UIApplication.registerForRemoteNotifications() не из основного потока

**Описание ревью**
Обернул метод в DispatchQueue.main.async {  }

**На что обратить внимание и как тестировать**
Протестировать можно на реальном устройстве  при установке приложения 

**Связанные таски**
https://trello.com/c/hFEqHx0h/397--