### PR TITLE
realm cocoa v3.1.0

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
 github "SVProgressHUD/SVProgressHUD" "2.2.2"
 github "onevcat/Kingfisher" "4.2.0"
-github "realm/realm-cocoa" "v3.0.1"
+github "realm/realm-cocoa" "v3.1.0"


### PR DESCRIPTION
**Тема ревью**
realm 3.0.1 собран под старой версией swift и из под carthage новым xcode не собирается

**Описание ревью**
при запуске сборки firstStep.sh качает бинарь realm 3.0.1 и пишет что framework собран под какой-то устаревшей версией swift, а локально у вас стоит новая версия
собирал под 
Apple Swift version 4.0.2 (swiftlang-900.0.69.2 clang-900.0.38

**На что обратить внимание и как тестировать**
при сборке пишет что realm собран под 4.0.0 чего-то там, а у вас 4.0.2

**Связанные таски**