### PR TITLE
fix memory leak of EventPreviewViewController

### DIFF
--- a/CHMeetupApp.xcodeproj/project.pbxproj
+++ b/CHMeetupApp.xcodeproj/project.pbxproj
@@ -257,6 +257,8 @@
 		ADCCA0FE1E936156009DAACE /* LabelTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADCCA0FB1E936156009DAACE /* LabelTableViewCell.swift */; };
 		ADCCA0FF1E936156009DAACE /* LabelTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = ADCCA0FC1E936156009DAACE /* LabelTableViewCell.xib */; };
 		ADCCA1001E936156009DAACE /* LabelTableViewCellModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADCCA0FD1E936156009DAACE /* LabelTableViewCellModel.swift */; };
+		B0A1FC11204DBA10007D501D /* ActionCellConfigurationControllerLeakTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0A1FC10204DBA10007D501D /* ActionCellConfigurationControllerLeakTests.swift */; };
+		B0A1FC12204DBDB7007D501D /* RealmSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A6268281E60742B00D51BEB /* RealmSwift.framework */; };
 		B744FA561FB07AD400F92D4B /* AlertHeaderTableViewCellModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B744FA551FB07AD400F92D4B /* AlertHeaderTableViewCellModel.swift */; };
 		B744FA581FB07B2A00F92D4B /* AlertHeaderTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B744FA571FB07B2A00F92D4B /* AlertHeaderTableViewCell.swift */; };
 		B744FA5A1FB07CCB00F92D4B /* AlertHeaderTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = B744FA591FB07CCB00F92D4B /* AlertHeaderTableViewCell.xib */; };
@@ -550,6 +552,7 @@
 		ADCCA0FB1E936156009DAACE /* LabelTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LabelTableViewCell.swift; sourceTree = "<group>"; };
 		ADCCA0FC1E936156009DAACE /* LabelTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = LabelTableViewCell.xib; sourceTree = "<group>"; };
 		ADCCA0FD1E936156009DAACE /* LabelTableViewCellModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LabelTableViewCellModel.swift; sourceTree = "<group>"; };
+		B0A1FC10204DBA10007D501D /* ActionCellConfigurationControllerLeakTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionCellConfigurationControllerLeakTests.swift; sourceTree = "<group>"; };
 		B744FA551FB07AD400F92D4B /* AlertHeaderTableViewCellModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertHeaderTableViewCellModel.swift; sourceTree = "<group>"; };
 		B744FA571FB07B2A00F92D4B /* AlertHeaderTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertHeaderTableViewCell.swift; sourceTree = "<group>"; };
 		B744FA591FB07CCB00F92D4B /* AlertHeaderTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = AlertHeaderTableViewCell.xib; sourceTree = "<group>"; };
@@ -582,6 +585,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B0A1FC12204DBDB7007D501D /* RealmSwift.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2089,6 +2093,7 @@
 		A1DBA4F11E71ED1200E3F1E5 /* CHMeetupAppTests */ = {
 			isa = PBXGroup;
 			children = (
+				B0A1FC0E204DB9E9007D501D /* Controllers */,
 				A1495AE61E76CD12003D8BE3 /* Validation */,
 				A1DBA4F41E71ED1200E3F1E5 /* Info.plist */,
 			);
@@ -2111,6 +2116,14 @@
 				ADCCA0FC1E936156009DAACE /* LabelTableViewCell.xib */,
 			);
 			path = LabelCell;
+			sourceTree = "<group>";
+		};
+		B0A1FC0E204DB9E9007D501D /* Controllers */ = {
+			isa = PBXGroup;
+			children = (
+				B0A1FC10204DBA10007D501D /* ActionCellConfigurationControllerLeakTests.swift */,
+			);
+			path = Controllers;
 			sourceTree = "<group>";
 		};
 		B744FA541FB07ACB00F92D4B /* AlertHeaderTableViewCell */ = {
@@ -2619,6 +2632,7 @@
 			files = (
 				A1495AE91E76CD2E003D8BE3 /* StringValidation.swift in Sources */,
 				A1495AEB1E76CD3D003D8BE3 /* StringValidationTests.swift in Sources */,
+				B0A1FC11204DBA10007D501D /* ActionCellConfigurationControllerLeakTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2778,6 +2792,10 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_ENABLE_MODULES = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
 				INFOPLIST_FILE = CHMeetupAppTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = cocoaheads.CHMeetupAppTests;
@@ -2793,6 +2811,10 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_ENABLE_MODULES = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
 				INFOPLIST_FILE = CHMeetupAppTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = cocoaheads.CHMeetupAppTests;

--- a/CHMeetupApp.xcodeproj/xcshareddata/xcschemes/Debug.xcscheme
+++ b/CHMeetupApp.xcodeproj/xcshareddata/xcschemes/Debug.xcscheme
@@ -26,8 +26,19 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A1DBA4EF1E71ED1200E3F1E5"
+               BuildableName = "CHMeetupAppTests.xctest"
+               BlueprintName = "CHMeetupAppTests"
+               ReferencedContainer = "container:CHMeetupApp.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
       <MacroExpansion>
          <BuildableReference
@@ -45,6 +56,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/CHMeetupApp/Sources/Common/Helpers/Importer/ImporterHelper.swift
+++ b/CHMeetupApp/Sources/Common/Helpers/Importer/ImporterHelper.swift
@@ -8,11 +8,23 @@
 
 import UIKit
 
-class ImporterHelper {
-  static func importToSave(event: EventEntity?,
-                           to type: ImportType,
-                           from viewController: UIViewController,
-                           with additionalAction: Action? = nil) {
+protocol ImporterHelper {
+  func isEventInStorage(event: EventEntity, type: ImportType) -> Bool
+  func importToSave(event: EventEntity?,
+                    to type: ImportType,
+                    from viewController: UIViewController,
+                    with additionalAction: Action?)
+}
+
+class ImporterHelpProvider: ImporterHelper {
+  func isEventInStorage(event: EventEntity, type: ImportType) -> Bool {
+    return Importer.isEventInStorage(event: event, type: type)
+  }
+
+  func importToSave(event: EventEntity?,
+                    to type: ImportType,
+                    from viewController: UIViewController,
+                    with additionalAction: Action?) {
     if let event = event {
       Importer.import(event: event, to: type, completion: { result in
         defer {

--- a/CHMeetupApp/Sources/Common/Helpers/Importer/ImporterHelper.swift
+++ b/CHMeetupApp/Sources/Common/Helpers/Importer/ImporterHelper.swift
@@ -9,15 +9,15 @@
 import UIKit
 
 protocol ImporterHelper {
-  func isEventInStorage(event: EventEntity, type: ImportType) -> Bool
+  func isEventInStorage(_ event: EventEntity, type: ImportType) -> Bool
   func importToSave(event: EventEntity?,
                     to type: ImportType,
                     from viewController: UIViewController,
                     with additionalAction: Action?)
 }
 
-class ImporterHelpProvider: ImporterHelper {
-  func isEventInStorage(event: EventEntity, type: ImportType) -> Bool {
+class ImporterHelperProvider: ImporterHelper {
+  func isEventInStorage(_ event: EventEntity, type: ImportType) -> Bool {
     return Importer.isEventInStorage(event: event, type: type)
   }
 

--- a/CHMeetupApp/Sources/Controllers/ActionCellConfigurationController/ActionCellConfigurationController.swift
+++ b/CHMeetupApp/Sources/Controllers/ActionCellConfigurationController/ActionCellConfigurationController.swift
@@ -12,6 +12,12 @@ typealias Action = () -> Void
 
 class ActionCellConfigurationController {
 
+  private let importerHelper: ImporterHelper
+
+  init(importerHelper: ImporterHelper = ImporterHelpProvider()) {
+    self.importerHelper = importerHelper
+  }
+
   func createImportAction(for event: EventEntity,
                           on viewController: UIViewController,
                           for importType: ImportType,
@@ -19,10 +25,14 @@ class ActionCellConfigurationController {
     let importToPermission: [ImportType: PermissionsType] = [.calendar: .calendar,
                                                              .reminder: .reminders]
     if let permission = importToPermission[importType] {
-      let isEventInStorage = Importer.isEventInStorage(event: event, type: importType)
+      let isEventInStorage = importerHelper.isEventInStorage(event: event, type: importType)
       if !isEventInStorage {
-        return addActionCell(on: viewController, for: permission, with: {
-          ImporterHelper.importToSave(event: event, to: importType, from: viewController) {
+        return addActionCell(on: viewController, for: permission, with: { [weak self, weak viewController] in
+          guard let vc = viewController else {
+            assertionFailure("view controller did release already")
+            return
+          }
+          self?.importerHelper.importToSave(event: event, to: importType, from: vc) {
             additionalAction?()
           }
         })
@@ -34,9 +44,9 @@ class ActionCellConfigurationController {
     return nil
   }
 
-  func addActionCell(on viewController: UIViewController,
-                     for type: PermissionsType,
-                     with additionalAction: Action?) -> ActionPlainObject? {
+  private func addActionCell(on viewController: UIViewController,
+                             for type: PermissionsType,
+                             with additionalAction: Action?) -> ActionPlainObject? {
     var actionPlainObject: ActionPlainObject? = nil
 
     let texts: [PermissionsType: String] = [.calendar: "Добавить в календарь".localized,
@@ -48,8 +58,13 @@ class ActionCellConfigurationController {
       let imageName = imagesNames[type]
       actionPlainObject = ActionPlainObject(
         text: text,
-        imageName: imageName, action: {
-          self.requireAccess(from: viewController, to: type,
+        imageName: imageName, action: { [weak self, weak viewController] in
+          guard let vc = viewController else {
+            assertionFailure("view controller did release already")
+            return
+          }
+
+          self?.requireAccess(from: vc, to: type,
                              with: {
                               additionalAction?()
           })
@@ -59,53 +74,6 @@ class ActionCellConfigurationController {
     }
 
     return actionPlainObject
-  }
-
-  func checkAccess(on viewController: UIViewController,
-                   for type: PermissionsType, with additionalAction: Action?) -> ActionPlainObject? {
-    var actionPlainObject: ActionPlainObject?
-
-    switch  type {
-    case .reminders:
-      if !PermissionsManager.isAllowed(type: type) {
-        actionPlainObject = ActionPlainObject(
-          text: "Подключите напоминания, чтобы не пропустить события".localized,
-          imageName: "img_icon_reminders", action: {
-            self.requireAccess(from: viewController, to: type,
-                               with: {
-                                additionalAction?()
-            })
-        })
-        return actionPlainObject
-      }
-    case .calendar:
-      if !PermissionsManager.isAllowed(type: type) {
-        actionPlainObject = ActionPlainObject(
-          text: "Подключите календарь, чтобы синхронизировать события".localized,
-          imageName: "img_icon_calendar", action: {
-            self.requireAccess(from: viewController, to: type,
-                               with: {
-                                additionalAction?()
-            })
-        })
-        return actionPlainObject
-      }
-    case .notifications:
-      if !PermissionsManager.isAllowed(type: type) {
-        actionPlainObject = ActionPlainObject(
-          text: "Включите оповещения, чтобы не пропустить анонсы".localized,
-          imageName: "img_icon_notifications", action: {
-            self.requireAccess(from: viewController, to: type,
-                               with: {
-                                additionalAction?()
-            })
-        })
-        return actionPlainObject
-      }
-    case .photosLibrary, .camera:
-      break
-    }
-    return nil
   }
 
   private func requireAccess(from viewController: UIViewController,

--- a/CHMeetupApp/Sources/Controllers/ActionCellConfigurationController/ActionCellConfigurationController.swift
+++ b/CHMeetupApp/Sources/Controllers/ActionCellConfigurationController/ActionCellConfigurationController.swift
@@ -14,7 +14,7 @@ class ActionCellConfigurationController {
 
   private let importerHelper: ImporterHelper
 
-  init(importerHelper: ImporterHelper = ImporterHelpProvider()) {
+  init(importerHelper: ImporterHelper = ImporterHelperProvider()) {
     self.importerHelper = importerHelper
   }
 
@@ -24,24 +24,23 @@ class ActionCellConfigurationController {
                           with additionalAction: Action? = nil) -> ActionPlainObject? {
     let importToPermission: [ImportType: PermissionsType] = [.calendar: .calendar,
                                                              .reminder: .reminders]
-    if let permission = importToPermission[importType] {
-      let isEventInStorage = importerHelper.isEventInStorage(event: event, type: importType)
-      if !isEventInStorage {
-        return addActionCell(on: viewController, for: permission, with: { [weak self, weak viewController] in
-          guard let vc = viewController else {
-            assertionFailure("view controller did release already")
-            return
-          }
-          self?.importerHelper.importToSave(event: event, to: importType, from: vc) {
-            additionalAction?()
-          }
-        })
-      }
-    } else {
+    guard let permission = importToPermission[importType] else {
       assertionFailure("No such permission")
+      return nil
+    }
+    guard !importerHelper.isEventInStorage(event, type: importType) else {
+      return nil
     }
 
-    return nil
+    return addActionCell(on: viewController, for: permission, with: { [weak self, weak viewController] in
+      guard let vc = viewController else {
+        assertionFailure("view controller did release already")
+        return
+      }
+      self?.importerHelper.importToSave(event: event, to: importType, from: vc) {
+        additionalAction?()
+      }
+    })
   }
 
   private func addActionCell(on viewController: UIViewController,

--- a/CHMeetupApp/Sources/ViewControllers/Events/EventPreview/DisplayModel/EventPreviewDisplayCollection.swift
+++ b/CHMeetupApp/Sources/ViewControllers/Events/EventPreview/DisplayModel/EventPreviewDisplayCollection.swift
@@ -10,6 +10,9 @@ import UIKit
 import CoreLocation
 
 class EventPreviewDisplayCollection: DisplayCollection {
+
+  private let actionCell = ActionCellConfigurationController()
+
   static var modelsForRegistration: [CellViewAnyModelType.Type] {
     return [ActionTableViewCellModel.self, TimePlaceTableViewCellModel.self, SpeechPreviewTableViewCellModel.self]
   }
@@ -108,8 +111,6 @@ class EventPreviewDisplayCollection: DisplayCollection {
                                 with tableView: UITableView,
                                 event: EventEntity) {
     actionPlainObjects = []
-
-    let actionCell = ActionCellConfigurationController()
 
     let calendarPermissionCell = actionCell.createImportAction(
       for: event,

--- a/CHMeetupApp/Sources/ViewControllers/Events/Registration/Confirm/DisplayModel/RegistrationConfirmDisplayCollection.swift
+++ b/CHMeetupApp/Sources/ViewControllers/Events/Registration/Confirm/DisplayModel/RegistrationConfirmDisplayCollection.swift
@@ -21,6 +21,7 @@ final class RegistrationConfirmDisplayCollection: NSObject, DisplayCollection, D
 
   private var sections: [Type] = [.header, .actionButtons]
   private var actionPlainObjects: [ActionPlainObject] = []
+  private let actionCell = ActionCellConfigurationController()
 
   weak var delegate: DisplayCollectionDelegate?
 
@@ -30,8 +31,6 @@ final class RegistrationConfirmDisplayCollection: NSObject, DisplayCollection, D
                                 with tableView: UITableView,
                                 event: EventEntity) {
     actionPlainObjects = []
-
-    let actionCell = ActionCellConfigurationController()
 
     let calendarPermissionCell = actionCell.createImportAction(for: event,
                                                                on: viewController,

--- a/CHMeetupAppTests/Controllers/ActionCellConfigurationControllerLeakTests.swift
+++ b/CHMeetupAppTests/Controllers/ActionCellConfigurationControllerLeakTests.swift
@@ -1,0 +1,60 @@
+//
+//  ActionCellConfigurationControllerLeakTests.swift
+//  CHMeetupAppTests
+//
+//  Created by Chingis Gomboev on 05/03/2018.
+//  Copyright © 2018 CocoaHeads Community. All rights reserved.
+//
+
+import XCTest
+@testable import CHMeetupApp
+
+// swiftlint:disable type_name
+final class ActionCellConfigurationControllerLeakTests: XCTestCase {
+// swiftlint:enable type_name
+
+  weak var viewController: UIViewController?
+  weak var actionCell: ActionCellConfigurationController?
+  var actionObject: ActionPlainObject?
+
+  override func tearDown() {
+    super.tearDown()
+    XCTAssertNil(actionCell, "ActionCell retail self, so its retain cycle leak")
+    XCTAssertNil(viewController, "viewController still alive, its retain cycle leak")
+
+    self.actionObject = nil
+  }
+
+  func testMemoryLeak() {
+
+    // GIVEN
+    class ImporterHelpMock: ImporterHelper {
+      var vc: UIViewController?
+      func importToSave(event: EventEntity?,
+                        to type: ImportType,
+                        from viewController: UIViewController,
+                        with additionalAction: Action?) {
+        self.vc = viewController
+      }
+      func isEventInStorage(event: EventEntity, type: ImportType) -> Bool {
+        return false
+      }
+    }
+
+    let event = EventEntity.templateEntity
+    let actionCell = ActionCellConfigurationController(importerHelper: ImporterHelpMock())
+    self.actionCell = actionCell
+    let vc = UIViewController()
+    self.viewController = vc
+
+    // WHEN
+    self.actionObject = actionCell.createImportAction(for: event,
+                                          on: vc,
+                                          for: .calendar) {}
+
+    // THEN
+    // Checking LEAK of actionCell & viewController in tearDown() func,
+    // it's easiest way to keep this test synchronous
+  }
+
+}


### PR DESCRIPTION
**Тема ревью**
Утечка памяти.

**Описание ревью**
Не освобождается экран ивента (EventPreviewViewController) если зайти на него и выйти обратно.
Пофиксил, покрыл тестом, добавил тестовый таргет для Debug схемы.

**На что обратить внимание и как тестировать**
кейс воспроизведения:
- открыть экран любого ивента(EventPreviewViewController), важно чтобы ивент не был добавлен в календарь и напоминания, или был уже прошедшим
- уйти с экрана назад в список ивентов
результат: экран не освобождается. при повторении кейса несколько раз, количество утекших объектов возрастает. 
скриншот Memory Graph
<img width="384" alt="screenshot" src="https://user-images.githubusercontent.com/1898138/36997051-7a049298-20c9-11e8-88dc-11332cf5dd18.png">

PS. пришлось залинковать RealmSwift.framework в тестовый таргет, так как везде фигурирует EventEntity, и его быстро не изолировать.