### PR TITLE
Sorry guys... my bad :((

### DIFF
--- a/CHMeetupApp/Sources/Common/Helpers/iBeacon/BeaconTransmitterExt.swift
+++ b/CHMeetupApp/Sources/Common/Helpers/iBeacon/BeaconTransmitterExt.swift
@@ -30,6 +30,6 @@ extension BeaconTransmitter {
   }
 
   private static func prepareData(for user: UserEntity) -> Data? {
-    return BeaconUserInfo(id: user.id, name: user.fullName, photoURL: user.photoURL).userData
+    return BeaconUserInfo(id: user.remoteId, name: user.fullName, photoURL: user.photoURL).userData
   }
 }


### PR DESCRIPTION
**Тема ревью**
Баг, из-за которого на экране "люди вокруг" отображается только один человек

**Описание ревью**
при трансмиттинге bluetooth сигнала отправлялся локальный `id` юзера, и, как оказалось, он у всех одинаковый, и равен 0. при сканировании сигналов этот id записывался в бд как первичный ключ для сущности `NearestUserEntity`. поэтому все сигналы перезатирали друг друга, у них был одинаковый идентификатор. 
Баг был допущен в этом коммите 
https://github.com/ichina/application/commit/6927058e2b6f818ae42a5eaff79a5d6d9e98188b#r29960310
Фикс заключается в том, чтобы трансмитить настоящий идентификатор юзера

**На что обратить внимание и как тестировать**
Теперь при открытии экрана "Люди вокруг" должны отображаться все люди окружающие вас

**Связанные таски**
