### PR TITLE
Hotfix/ibeacon indicator

### DIFF
--- a/CHMeetupApp.xcodeproj/project.pbxproj
+++ b/CHMeetupApp.xcodeproj/project.pbxproj
@@ -279,6 +279,8 @@
 		B00775C5205F1E40007280FA /* IBeaconPeripheralMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = B00775C4205F1E40007280FA /* IBeaconPeripheralMock.swift */; };
 		B00775C7205F1E50007280FA /* IBeaconPeripheralDelegateMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = B00775C6205F1E50007280FA /* IBeaconPeripheralDelegateMock.swift */; };
 		B00775C9205F1E58007280FA /* ICentralManagerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = B00775C8205F1E58007280FA /* ICentralManagerMock.swift */; };
+		B01035CF2118C9E500174732 /* MainViewDisplayCollectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B01035CE2118C9E500174732 /* MainViewDisplayCollectionTests.swift */; };
+		B01035D12118D08900174732 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = B01035D02118D08900174732 /* main.swift */; };
 		B016515120623B7F007D93B2 /* ActionDetailIconCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = B016514E20623B7F007D93B2 /* ActionDetailIconCell.xib */; };
 		B016515220623B7F007D93B2 /* ActionDetailIconCellModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B016514F20623B7F007D93B2 /* ActionDetailIconCellModel.swift */; };
 		B016515320623B7F007D93B2 /* ActionDetailIconCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B016515020623B7F007D93B2 /* ActionDetailIconCell.swift */; };
@@ -614,6 +616,8 @@
 		B00775C4205F1E40007280FA /* IBeaconPeripheralMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IBeaconPeripheralMock.swift; sourceTree = "<group>"; };
 		B00775C6205F1E50007280FA /* IBeaconPeripheralDelegateMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IBeaconPeripheralDelegateMock.swift; sourceTree = "<group>"; };
 		B00775C8205F1E58007280FA /* ICentralManagerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ICentralManagerMock.swift; sourceTree = "<group>"; };
+		B01035CE2118C9E500174732 /* MainViewDisplayCollectionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MainViewDisplayCollectionTests.swift; sourceTree = "<group>"; };
+		B01035D02118D08900174732 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		B016514E20623B7F007D93B2 /* ActionDetailIconCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; name = ActionDetailIconCell.xib; path = ActionDetailIconCell/ActionDetailIconCell.xib; sourceTree = "<group>"; };
 		B016514F20623B7F007D93B2 /* ActionDetailIconCellModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ActionDetailIconCellModel.swift; path = ActionDetailIconCell/ActionDetailIconCellModel.swift; sourceTree = "<group>"; };
 		B016515020623B7F007D93B2 /* ActionDetailIconCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ActionDetailIconCell.swift; path = ActionDetailIconCell/ActionDetailIconCell.swift; sourceTree = "<group>"; };
@@ -820,6 +824,7 @@
 		221F4F8F1E5C0B6C0009FD07 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				B01035D02118D08900174732 /* main.swift */,
 				22323FA11E70C43800522E5C /* AppDelegate.swift */,
 				221F4F901E5C0B6C0009FD07 /* Common */,
 				221F4F941E5C0B6C0009FD07 /* Controllers */,
@@ -2337,6 +2342,7 @@
 		B0A1FC0E204DB9E9007D501D /* Controllers */ = {
 			isa = PBXGroup;
 			children = (
+				B01035CE2118C9E500174732 /* MainViewDisplayCollectionTests.swift */,
 				B0A1FC10204DBA10007D501D /* ActionCellConfigurationControllerLeakTests.swift */,
 			);
 			path = Controllers;
@@ -2733,6 +2739,7 @@
 				32DD63021EA8C92E005B565E /* ChooseProfilePhotoTableViewCell.swift in Sources */,
 				B0331344205C2E7F00F6DBB5 /* FindNearestViewDisplayCollection.swift in Sources */,
 				4D9D24241E7B2FE300FA5E93 /* ActionTableViewCellModel.swift in Sources */,
+				B01035D12118D08900174732 /* main.swift in Sources */,
 				22323F2E1E70C0E500522E5C /* Utility.swift in Sources */,
 				A168379C1E7E979800A12B3B /* OptionTableViewCellModel.swift in Sources */,
 				22323F521E70C18700522E5C /* EventPlainObject.swift in Sources */,
@@ -2879,6 +2886,7 @@
 				B00775C5205F1E40007280FA /* IBeaconPeripheralMock.swift in Sources */,
 				B0E2ABC3205F730A00F0247A /* BeaconStorageTests.swift in Sources */,
 				B00775C3205F1E17007280FA /* BeaconScannerDelegateMock.swift in Sources */,
+				B01035CF2118C9E500174732 /* MainViewDisplayCollectionTests.swift in Sources */,
 				B003C9F5205F39CF004BC58D /* BeaconScanningOperationTests.swift in Sources */,
 				A1495AE91E76CD2E003D8BE3 /* StringValidation.swift in Sources */,
 				A1495AEB1E76CD3D003D8BE3 /* StringValidationTests.swift in Sources */,

--- a/CHMeetupApp/Sources/AppDelegate.swift
+++ b/CHMeetupApp/Sources/AppDelegate.swift
@@ -11,7 +11,6 @@ import UserNotifications
 import Fabric
 import Crashlytics
 
-@UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate, ActiveWindowManager {
 
   var pushHandler = PushHandler()

--- a/CHMeetupApp/Sources/ViewControllers/Feed/Main/MainViewDisplayCollection.swift
+++ b/CHMeetupApp/Sources/ViewControllers/Feed/Main/MainViewDisplayCollection.swift
@@ -139,16 +139,19 @@ extension MainViewDisplayCollection {
 
   func needShowSwitchCell() -> Bool {
     guard modelCollection.count > 0 else { return false }
-    let event = modelCollection[0]
 
-    var isEventToday = event.startDate.isToday
-    #if DEBUG //tested without
-      isEventToday = true
-    #endif
-    //If your Request is Approved And event date is today
-    guard event.status == .approved, isEventToday else { return false }
+    for idx in 0 ..< modelCollection.count {
+      let event = modelCollection[idx]
 
-    return true
+      let isEventToday = event.startDate.isToday
+
+      //If your Request is Approved And event date is today
+      if event.status == .approved, isEventToday {
+        return true
+      }
+    }
+
+    return false
   }
 }
 

--- a/CHMeetupApp/Sources/main.swift
+++ b/CHMeetupApp/Sources/main.swift
@@ -1,0 +1,27 @@
+//
+//  main.swift
+//  CHMeetupApp
+//
+//  Created by Chingis Gomboev on 06/08/2018.
+//  Copyright © 2018 CocoaHeads Community. All rights reserved.
+//
+
+import UIKit
+import Foundation
+
+class TestingAppDelegate: UIResponder, UIApplicationDelegate {
+  override init() {
+    RealmController.shared.setup()
+  }
+}
+let isRunningTests = ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil
+
+UIApplicationMain(
+  CommandLine.argc,
+  UnsafeMutableRawPointer(CommandLine.unsafeArgv)
+    .bindMemory(
+      to: UnsafeMutablePointer<Int8>.self,
+      capacity: Int(CommandLine.argc)),
+  nil,
+  NSStringFromClass(isRunningTests ? TestingAppDelegate.self : AppDelegate.self)
+)

--- a/CHMeetupAppTests/Controllers/MainViewDisplayCollectionTests.swift
+++ b/CHMeetupAppTests/Controllers/MainViewDisplayCollectionTests.swift
@@ -1,0 +1,52 @@
+//
+//  MainViewDisplayCollectionTests.swift
+//  CHMeetupAppTests
+//
+//  Created by Chingis Gomboev on 06/08/2018.
+//  Copyright © 2018 CocoaHeads Community. All rights reserved.
+//
+
+import XCTest
+@testable import CHMeetupApp
+import RealmSwift
+
+final class MainViewDisplayCollectionTests: XCTestCase {
+
+  var controller: MainViewDisplayCollection!
+
+  override func setUp() {
+    super.setUp()
+
+    controller = MainViewDisplayCollection()
+  }
+
+  func testNeedShowSwitchCell() {
+
+    // GIVEN
+    controller.modelCollection = TemplateModelCollection<EventEntity>(list: eventList())
+
+    // WHEN
+    let need = controller.needShowSwitchCell()
+
+    // THEN
+    XCTAssert(controller.modelCollection.count == 2, "modelCollection has incorrect objects count")
+    XCTAssert(need, "incorrect value for showing swift cell")
+  }
+
+  private func eventList() -> List<EventEntity> {
+    let list = List<EventEntity>()
+    list.append({
+      let event = EventEntity.templateEntity
+      event.id = 1
+      return event
+    }())
+    list.append({
+      let event = EventEntity.templateEntity
+      event.id = 2
+      event.status = .approved
+      event.startDate = Date()
+      return event
+      }())
+    return list
+  }
+}


### PR DESCRIPTION
**Тема ревью**
Ячейка для включения режима "Люди вокруг" не отображается, если есть более одного upcoming event'a

**Описание ревью**
в функции для поверки, нужно ли показывать ячейку, проверялся только первый в списке ивент, добавил проверку всех upcoming ивентов. Кейс может произойти в случае например если будут анонсированы и доступны для регистрации несколько ивентов одновременно(например Москва и Питер)
Первым коммитом написал провальный тест, вторым фикс для этого теста

**На что обратить внимание и как тестировать**
при анонсе двух ивентов ячейка для включения режима "Люди вокруг" отображается

**Связанные таски**
