### PR TITLE
Postpone fetchEvents for main view after view appearing

### DIFF
--- a/CHMeetupApp/Sources/ViewControllers/Feed/Main/MainViewController.swift
+++ b/CHMeetupApp/Sources/ViewControllers/Feed/Main/MainViewController.swift
@@ -38,8 +38,12 @@ class MainViewController: UIViewController, DisplayCollectionWithTableViewDelega
     super.viewWillAppear(animated)
     self.tableView.reloadData()
 
-    fetchEvents()
     profileNavigationController?.pushEditProfileTo(self.navigationController)
+  }
+
+  override func viewDidAppear(_ animated: Bool) {
+    super.viewDidAppear(animated)
+    fetchEvents()
   }
 
   override func az_tabBarItemContentView() -> AZTabBarItemView {


### PR DESCRIPTION
**Тема ревью**
Исправление падения на экране деталей события.

**Описание ревью**
При swipe to pop вызывается viewWillAppear(_:). Предполагалось, что после viewWillAppear(_:) вью будет показана, но это не так в случае прерывания swipe to pop. В пулл реквесте отсрочил инициирование загрузки данных для MainViewController до появления вью, это позволило избегать падения.

**На что обратить внимание и как тестировать**
Воспроизведение падения, которое исправлено в этом пулл реквесте:
- запустить приложение (должно быть хотя бы одно будущее событие)
- перейти в событие
- начать swipe to pop
- прервать swipe to pop (остаться на экране выбранного события)
- проскролить до новой ячейки

**Связанные таски**
