### PR TITLE
Фикс краша при установке фокуса в поле ввода

### DIFF
--- a/CHMeetupApp/Sources/Common/Helpers/KeyboardHandler/KeyboardHandler.swift
+++ b/CHMeetupApp/Sources/Common/Helpers/KeyboardHandler/KeyboardHandler.swift
@@ -40,17 +40,7 @@ struct KeyboardInfo {
   let curve: UIView.AnimationCurve
 
   func animate(_ animations: @escaping () -> Void, completion: ((Bool) -> Void)? = nil) {
-    let curveOption: UIView.AnimationOptions
-    switch curve {
-    case .linear:
-      curveOption = .curveLinear
-    case .easeIn:
-      curveOption = .curveEaseIn
-    case .easeOut:
-      curveOption = .curveEaseOut
-    case .easeInOut:
-      curveOption = .curveEaseInOut
-    }
+    let curveOption = UIView.AnimationOptions(rawValue: UInt(curve.rawValue) << 16)
 
     UIView.animate(withDuration: duration,
                    delay: 0,


### PR DESCRIPTION
**Тема ревью**
Исправление краша при установке фокуса в любое из полей на экране.

**Описание ревью**
В прилетающем при открытии клавиатуры словаре `info?[UIResponder.keyboardAnimationCurveUserInfoKey]` почему-то равен 7 при 4 кейсах в `enum UIView.AnimationCurve : Int`
Изменил способ конвертации между `enum UIView.AnimationCurve` и `struct AnimationOptions : OptionSet`
**На что обратить внимание и как тестировать**
Приложение не крашится при установке фокуса в любое поле и в целом поведение при работе с клавиатурой выглядит корректным

**Связанные таски**
