### PR TITLE
Отключение тёмной темы

### DIFF
--- a/CHMeetupApp/Resources/Config/Info.plist
+++ b/CHMeetupApp/Resources/Config/Info.plist
@@ -118,6 +118,8 @@
 	<array>
 		<string>armv7</string>
 	</array>
+	<key>UIUserInterfaceStyle</key>
+	<string>Light</string>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>


### PR DESCRIPTION
**Тема ревью**
Из-за включённой тёмной темы не видны плейсхолдеры в текстовых полях

**Описание ревью**
Темная тема по умолчанию отключена добавлением UIUserInterfaceStyle = Light в Info.plist

**На что обратить внимание и как тестировать**
Приложение не изменяет своего вида при переключении темы iOS

**Связанные таски**
