### PR TITLE
[qXUdCQay] Increment major & minor version to 1.5

### DIFF
--- a/CHMeetupApp.xcodeproj/project.pbxproj
+++ b/CHMeetupApp.xcodeproj/project.pbxproj
@@ -3043,6 +3043,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/CHMeetupApp/Resources/Config/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				MARKETING_VERSION = 1.5;
 				PRODUCT_BUNDLE_IDENTIFIER = cocoaheads.russia.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "CocoaHeads Opensource";
@@ -3068,6 +3069,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/CHMeetupApp/Resources/Config/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				MARKETING_VERSION = 1.5;
 				PRODUCT_BUNDLE_IDENTIFIER = cocoaheads.russia.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "CocoaHeads Opensource";

--- a/CHMeetupApp/Resources/Config/Info.plist
+++ b/CHMeetupApp/Resources/Config/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.4</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>


### PR DESCRIPTION
**Тема ревью**
Поднял версию приложения до 1.5, чтобы автоматически загружать в ITC и отправлять на ревью в Store

**Описание ревью**
При **деплое** с **Bitrise** получаю следующую **ошибку**:
```
ERROR ITMS-90062: "This bundle is invalid. The value for key CFBundleShortVersionString [1.4] in the Info.plist file must contain a higher version than that of the previously approved version [1.4.2]. Please find more information about CFBundleShortVersionString at https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundleshortversionstring"
2020-01-09 20:47:28.042 altool[17499:37963] *** Error: Errors uploading '/Users/vagrant/deploy/Release.ipa'
```
Раньше версия приложения (ключ **CFBundleShortVersionString**) имела вид **1.4.2**, а **build** версия (ключ **CFBundleVersion**) **не использовалась**. 
Теперь ключ **CFBundleShortVersionString** состоит только из **мажорной** и **минорной версий** (как и было изначально) и равен **1.5**, а ключ **CFBundleVersion** приложения **проставляется автоматически** по **номеру сборки CI** на **Bitrise**.
Так как **CFBundleShortVersionString** в сторе (**1.4.2**) выше **1.4**, то **деплой** новой **сборки** **не проходит в ITC** и требуется **поднять минорную версию**.

**На что обратить внимание и как тестировать**
После клонирования/подтягивания изменений приложения в поле version в Xcode стоит версия 1.5

**Связанные таски**
